### PR TITLE
Warning removed when calling seq function

### DIFF
--- a/R/BM.R
+++ b/R/BM.R
@@ -1,7 +1,7 @@
 BBridge <- function(x=0, y=0, t0=0, T=1, N=100){
   if(T<= t0) stop("wrong times")
   dt <- (T-t0)/N
-  t <- seq(t0, T, length=N+1)
+  t <- seq(t0, T, length.out=N+1)
   X <- c(0,cumsum( rnorm(N)*sqrt(dt)))
   BB <- x + X - (t-t0)/(T-t0)*(X[N+1]-y+x)
   X <- ts(BB, start=t0,deltat=dt)
@@ -11,7 +11,7 @@ BBridge <- function(x=0, y=0, t0=0, T=1, N=100){
 BM <- function(x=0, t0=0, T=1, N=100){
   if(T<= t0) stop("wrong times")
   dt <- (T-t0)/N
-  t <- seq(t0,T, length=N+1)
+  t <- seq(t0,T, length.out=N+1)
   X <- ts(cumsum(c(x,rnorm(N)*sqrt(dt))),start=t0, deltat=dt)
   return(invisible(X))
 }

--- a/R/ksmooth.R
+++ b/R/ksmooth.R
@@ -1,6 +1,6 @@
 ksdrift <- function(x,bw,n=512){
  len <- length(x)
- xval <- seq(min(x), max(x), length=n)
+ xval <- seq(min(x), max(x), length.out=n)
  if(missing(bw))
   bw <- len^(-1/5)*sd(x)
   y <- sapply(xval, function(xval) { 
@@ -11,7 +11,7 @@ ksdrift <- function(x,bw,n=512){
  
 ksdiff <- function(x,bw,n=512){
  len <- length(x)
- xval <- seq(min(x), max(x), length=n)
+ xval <- seq(min(x), max(x), length.out=n)
  if(missing(bw))
   bw <- len^(-1/5)*sd(x)
   y <- sapply(xval, function(xval) { 

--- a/R/sde.sim.R
+++ b/R/sde.sim.R
@@ -84,7 +84,7 @@ sde.sim <- function (t0 = 0, T = 1, X0 = 1, N = 100, delta, drift, sigma,
     if (t0 < 0 || T < 0) 
         stop("please use positive times!")
     if (missing(delta)) {
-        t <- seq(t0, T, length = N + 1)
+        t <- seq(t0, T, length.out = N + 1)
     }
     else {
         t <- c(t0, t0 + cumsum(rep(delta, N)))


### PR DESCRIPTION
The R seq function is 
seq(from = 1, to = 1, by = ((to - from)/(length.out - 1)),
    length.out = NULL, along.with = NULL, …)
using length instead of length.out is causing "partial matching" of arguments, and this is raising warnings if warnPartialMatchArgs is activated in global options

